### PR TITLE
Dependabot: add configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "⬆️ "
+    pull-request-branch-name:
+      separator: "-"
+    reviewers:
+      - "UKHomeOffice/hocs-core"
+    ignore:
+      - dependency-name: "aws-java-sdk"
+        update-types: [ "version-update:semver-patch" ]


### PR DESCRIPTION
At present this repository has not been kept upto date with the packages
that it uses. This change adds dependabot to support the upgrading of
required dependancies. This is currently set to happen daily, inform the
`hocs-core` team and ignore patch versions of the aws-java-sdk unless
they are security related.